### PR TITLE
make toolbox debug logging optional

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -137,47 +137,58 @@ const DuringExec = toolbox_pkg.Repositories(.{
 pub fn build(builder: *std.Build) !void {
     const target = builder.standardTargetOptions(.{});
     const optimize = builder.standardOptimizeOption(.{});
+    const logging = builder.option(bool, "debug-build-script", "enable debug logging for the build script") orelse false;
 
-    var toolbox = try Toolbox.init(FromZon, DuringExec, builder, .ReleaseFast, .cimgui_zig, "0x4e4978d2929b7bd9", &.{
-        "build", "dcimgui",
-    }, .{
-        .toolbox = .{
-            .name = "tiawl/toolbox",
-            .host = .github,
-            .ref = .tag,
+    var toolbox = try Toolbox.init(
+        FromZon,
+        DuringExec,
+        builder,
+        if (logging) .Debug else .ReleaseFast,
+        .cimgui_zig,
+        "0x4e4978d2929b7bd9",
+        &.{
+            "build", "dcimgui",
         },
-        .vulkan_zig = .{
-            .name = "tiawl/vulkan.zig",
-            .host = .github,
-            .ref = .tag,
+        .{
+            .toolbox = .{
+                .name = "tiawl/toolbox",
+                .host = .github,
+                .ref = .tag,
+            },
+            .vulkan_zig = .{
+                .name = "tiawl/vulkan.zig",
+                .host = .github,
+                .ref = .tag,
+            },
+            .glfw_zig = .{
+                .name = "tiawl/glfw.zig",
+                .host = .github,
+                .ref = .tag,
+            },
+            .sdl = .{
+                .name = "castholm/SDL",
+                .host = .github,
+                .ref = .commit,
+            },
+            .zigglgen = .{
+                .name = "castholm/zigglgen",
+                .host = .github,
+                .ref = .commit,
+            },
         },
-        .glfw_zig = .{
-            .name = "tiawl/glfw.zig",
-            .host = .github,
-            .ref = .tag,
+        .{
+            .imgui = .{
+                .name = "ocornut/imgui",
+                .host = .github,
+                .ref = .tag,
+            },
+            .dcimgui = .{
+                .name = "dearimgui/dear_bindings",
+                .host = .github,
+                .ref = .commit,
+            },
         },
-        .sdl = .{
-            .name = "castholm/SDL",
-            .host = .github,
-            .ref = .commit,
-        },
-        .zigglgen = .{
-            .name = "castholm/zigglgen",
-            .host = .github,
-            .ref = .commit,
-        },
-    }, .{
-        .imgui = .{
-            .name = "ocornut/imgui",
-            .host = .github,
-            .ref = .tag,
-        },
-        .dcimgui = .{
-            .name = "dearimgui/dear_bindings",
-            .host = .github,
-            .ref = .commit,
-        },
-    });
+    );
     defer toolbox.deinit();
 
     const path = try Paths.init(&toolbox);

--- a/build.zig
+++ b/build.zig
@@ -95,7 +95,12 @@ fn update(toolbox: *Toolbox, path: *const Paths) !void {
                         stem,
                     }),
                 });
-                if (toolbox_pkg.isCHeader(entry.name) and toolbox_pkg.exists(backend_cpp) and std.mem.startsWith(u8, entry.name, "imgui") and !std.meta.isError(std.fs.accessAbsolute(cpp_template, .{})) and !std.meta.isError(std.fs.accessAbsolute(h_template, .{}))) {
+                if (toolbox_pkg.isCHeader(entry.name) and
+                    toolbox_pkg.exists(backend_cpp) and
+                    std.mem.startsWith(u8, entry.name, "imgui") and
+                    !std.meta.isError(std.fs.accessAbsolute(cpp_template, .{})) and
+                    !std.meta.isError(std.fs.accessAbsolute(h_template, .{})))
+                {
                     backend_h = toolbox.pathJoin(&.{
                         path.getBackends(), entry.name,
                     });
@@ -133,7 +138,7 @@ pub fn build(builder: *std.Build) !void {
     const target = builder.standardTargetOptions(.{});
     const optimize = builder.standardOptimizeOption(.{});
 
-    var toolbox = try Toolbox.init(FromZon, DuringExec, builder, optimize, .cimgui_zig, "0x4e4978d2929b7bd9", &.{
+    var toolbox = try Toolbox.init(FromZon, DuringExec, builder, .ReleaseFast, .cimgui_zig, "0x4e4978d2929b7bd9", &.{
         "build", "dcimgui",
     }, .{
         .toolbox = .{
@@ -214,7 +219,10 @@ pub fn build(builder: *std.Build) !void {
 
     var it = dcimgui_dir.iterate();
     while (try it.next()) |*entry| {
-        if ((std.mem.startsWith(u8, entry.name, "imgui") or std.mem.startsWith(u8, entry.name, "dcimgui")) and toolbox_pkg.isCppSource(entry.name) and entry.kind == .file) {
+        if ((std.mem.startsWith(u8, entry.name, "imgui") or std.mem.startsWith(u8, entry.name, "dcimgui")) and
+            toolbox_pkg.isCppSource(entry.name) and
+            entry.kind == .file)
+        {
             try toolbox.addSource(lib, path.getDcimgui(), entry.name, flags.slice());
         }
     }


### PR DESCRIPTION
Stop toolbox from needlessly printing debug infos on every build.