### PR TITLE
Fix undefined behavior causing crash on ubuntu 24 in glfw vulkan example.

### DIFF
--- a/examples/example_glfw_vulkan/main.zig
+++ b/examples/example_glfw_vulkan/main.zig
@@ -9,17 +9,17 @@ pub const c = @cImport({
     @cInclude("backends/dcimgui_impl_vulkan.h");
 });
 
-var g_Allocator: *c.VkAllocationCallbacks = undefined;
+var g_Allocator: ?*c.VkAllocationCallbacks = null;
 var g_Instance: c.VkInstance = undefined;
 var g_PhysicalDevice: c.VkPhysicalDevice = undefined;
 var g_Device: c.VkDevice = undefined;
 var g_QueueFamily: ?u32 = null;
 var g_Queue: c.VkQueue = undefined;
 var g_DebugReport: c.VkDebugReportCallbackEXT = undefined;
-var g_PipelineCache: c.VkPipelineCache = undefined;
+var g_PipelineCache: c.VkPipelineCache = null;
 var g_DescriptorPool: c.VkDescriptorPool = undefined;
 
-var g_MainWindowData: c.ImGui_ImplVulkanH_Window = undefined;
+var g_MainWindowData: c.ImGui_ImplVulkanH_Window = .{};
 var g_MinImageCount: u32 = 2;
 var g_SwapChainRebuild: bool = false;
 


### PR DESCRIPTION
Initialise g_Allocator, g_PipelineCache, and g_MainWindowData in the glfw vulkan example to prevent undefined behavior during initialisation.

(cherry picked from commit 99935f2edf48186906d59844e0650c78490ae34d)